### PR TITLE
item_identifier_method_code should not reference curation_concern

### DIFF
--- a/lib/generators/irus_analytics/inject_controller_hooks/inject_controller_hooks_generator.rb
+++ b/lib/generators/irus_analytics/inject_controller_hooks/inject_controller_hooks_generator.rb
@@ -145,7 +145,8 @@ class IrusAnalytics::InjectControllerHooksGenerator < Rails::Generators::Base
     <<-EOS
     def #{ITEM_IDENTIFIER_METHOD_NAME}
       # return the OAI identifier
-      curation_concern.oai_identifier
+      # http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
+      CatalogController.blacklight_config.oai[:provider][:record_prefix] + ":" + params[:id]
     end
     EOS
   end


### PR DESCRIPTION
OAI identifer format, http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm